### PR TITLE
set ace gem dependencies back to upstream

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ group :production do
   gem 'newrelic_rpm', '~> 3.9'
 end
 
-gem 'ace-rails-ap', github: 'grounds/ace-rails-ap', branch: 'ace-v1.1.8'
+gem 'ace-rails-ap', '~> 3.0'
 gem 'modernizr-rails', '~> 2.7'
 gem 'mousetrap-rails', '~> 1.4'
 gem 'font-awesome-rails', '~> 4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,7 @@
-GIT
-  remote: git://github.com/grounds/ace-rails-ap.git
-  revision: e8dcba5cf8004ab8685d66cc97fb89cc7e7900da
-  branch: ace-v1.1.8
-  specs:
-    ace-rails-ap (3.0.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
+    ace-rails-ap (3.0.2)
     actionmailer (4.1.8)
       actionpack (= 4.1.8)
       actionview (= 4.1.8)
@@ -193,7 +187,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  ace-rails-ap!
+  ace-rails-ap (~> 3.0)
   capybara (~> 2.4)
   coffee-rails (~> 4.0)
   factory_girl_rails (~> 4.5)


### PR DESCRIPTION
PR with ace v1.1.8 has been merged upstream
